### PR TITLE
Add basic dockerfile for dockerizing spring boot app

### DIFF
--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -1,5 +1,14 @@
-FROM java:8-jdk-alpine
-COPY ./build/libs/chat-server-0.0.1-SNAPSHOT.jar /usr/app/
-WORKDIR /usr/app
+FROM gradle:6.3.0-jdk8 AS build
+COPY --chown=gradle:gradle . /home/gradle/src
+WORKDIR /home/gradle/src
+RUN gradle build --no-daemon 
+
+FROM openjdk:8-jre-slim
+
 EXPOSE 8080
+
+RUN mkdir /app
+
+COPY --from=build /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar
 ENTRYPOINT ["java", "-jar", "chat-server-0.0.1-SNAPSHOT.jar"]
+

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -8,5 +8,5 @@ FROM openjdk:8-jre-slim
 RUN mkdir /app
 
 COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-Dspring.data.mongodb.uri=mongodb://api-database:27017/db", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-Dspring.data.mongodb.uri=mongodb://database:27017/db", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
 

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -9,4 +9,3 @@ RUN mkdir /app
 
 COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar
 ENTRYPOINT ["java", "-Dspring.data.mongodb.uri=mongodb://database:27017/db", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
-

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -1,0 +1,5 @@
+FROM java:8-jdk-alpine
+COPY ./build/libs/chat-server-0.0.1-SNAPSHOT.jar /usr/app/
+WORKDIR /usr/app
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "chat-server-0.0.1-SNAPSHOT.jar"]

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -5,10 +5,8 @@ RUN gradle bootJar
 
 FROM openjdk:8-jre-slim
 
-EXPOSE 8080
-
 RUN mkdir /app
 
 COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar
-ENTRYPOINT ["java", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
+ENTRYPOINT ["java", "-Dspring.data.mongodb.uri=mongodb://api-database:27017/db", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
 

--- a/chat-server/Dockerfile
+++ b/chat-server/Dockerfile
@@ -1,7 +1,7 @@
 FROM gradle:6.3.0-jdk8 AS build
 COPY --chown=gradle:gradle . /home/gradle/src
 WORKDIR /home/gradle/src
-RUN gradle build --no-daemon 
+RUN gradle bootJar
 
 FROM openjdk:8-jre-slim
 
@@ -9,6 +9,6 @@ EXPOSE 8080
 
 RUN mkdir /app
 
-COPY --from=build /home/gradle/src/build/libs/*.jar /app/spring-boot-application.jar
-ENTRYPOINT ["java", "-jar", "chat-server-0.0.1-SNAPSHOT.jar"]
+COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar
+ENTRYPOINT ["java", "-jar", "/app/chat-server-0.0.1-SNAPSHOT.jar"]
 

--- a/chat-server/README.md
+++ b/chat-server/README.md
@@ -5,9 +5,13 @@ Pet-project of participant Dell mentorship program. Made with Java.
 ## Server part
 
 
-### 1. Execution
-1. docker build . -t gitlogue-server
-2. docker run -p 8080:8080 gitlogue-server
+### 1. Docker
+1. ```docker-compose up```
+
+### 2. Development server
+1. ```gradle bootJar```
+2. Navigate to ```build/libs/```
+3. ```java -jar chat-server-0.0.1-SNAPSHOT.jar```
 
 ### 2. REST API 
 | Method | Type | Arguments' type | Arguments | Description |

--- a/chat-server/README.md
+++ b/chat-server/README.md
@@ -6,9 +6,8 @@ Pet-project of participant Dell mentorship program. Made with Java.
 
 
 ### 1. Execution
-1. ```gradle bootJar```
-2. Navigate to ```build/libs/```
-3. ```java -jar chat-server-0.0.1-SNAPSHOT.jar```
+1. docker build . -t gitlogue-server
+2. docker run -p 8080:8080 gitlogue-server
 
 ### 2. REST API 
 | Method | Type | Arguments' type | Arguments | Description |

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -1,29 +1,8 @@
-import com.bmuschko.gradle.docker.tasks.container.*
-import com.bmuschko.gradle.docker.tasks.image.*
-
-buildscript {
-    ext {
-        depVersion = [
-                gradle_docker_plugin: '6.4.0'
-        ]
-    }
-    
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "com.bmuschko:gradle-docker-plugin:${depVersion.gradle_docker_plugin}"
-    }
-}
-
 plugins {
     id 'org.springframework.boot' version '2.2.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-    id 'com.bmuschko.docker-spring-boot-application' version '6.4.0'
     id 'java'
 }
-
-apply plugin: 'com.bmuschko.docker-remote-api'
 
 group = 'com.vinnik.chat'
 version = '0.0.1-SNAPSHOT'
@@ -31,7 +10,6 @@ sourceCompatibility = '1.8'
 
 repositories {
     mavenCentral()
-    mavenLocal()
 }
 
 dependencies {
@@ -42,34 +20,3 @@ dependencies {
     implementation 'org.springframework.security:spring-security-test'
     implementation 'org.hibernate:hibernate-core:5.4.14.Final'
 }
-
-def dockerBuildDir = 'build/docker/'
-
-task createDockerfile(type: Dockerfile) {
-    destFile = project.file("$dockerBuildDir/Dockerfile")
-    from "gradle:6.3.0-jdk8 AS build"
-    instruction "COPY --chown=gradle:gradle . /home/gradle/src"
-    instruction "WORKDIR /home/gradle/src"
-    instruction "RUN cd .."
-    instruction "RUN gradle bootJar"
-    from "openjdk:8-jre-slim"
-    instruction "RUN mkdir /app"
-    instruction "COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar"
-    instruction "ENTRYPOINT [\"java\", \"-Dspring.data.mongodb.uri=mongodb://database:27017/db\", \"-jar\", \"/app/chat-server-0.0.1-SNAPSHOT.jar\"]"
-}
-
-def clearProductionFiles() {
-    delete 'docker'
-}
-
-task clear() {
-    clearProductionFiles()
-}
-
-clean.dependsOn clear
-
-task buildImage(type: DockerBuildImage) {
-    inputDir = file(dockerBuildDir)
-    images.add('myapp:latest')
-}
-

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -1,8 +1,29 @@
+import com.bmuschko.gradle.docker.tasks.container.*
+import com.bmuschko.gradle.docker.tasks.image.*
+
+buildscript {
+    ext {
+        depVersion = [
+                gradle_docker_plugin: "6.4.0"
+        ]
+    }
+    
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "com.bmuschko:gradle-docker-plugin:${depVersion.gradle_docker_plugin}"
+    }
+}
+
 plugins {
     id 'org.springframework.boot' version '2.2.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'java'
 }
+
+apply plugin: 'com.bmuschko.docker-remote-api'
+apply plugin: 'com.bmuschko.docker-java-application'
 
 group = 'com.vinnik.chat'
 version = '0.0.1-SNAPSHOT'
@@ -10,6 +31,7 @@ sourceCompatibility = '1.8'
 
 repositories {
     mavenCentral()
+    mavenLocal()
 }
 
 dependencies {
@@ -20,3 +42,37 @@ dependencies {
     implementation 'org.springframework.security:spring-security-test'
     implementation 'org.hibernate:hibernate-core:5.4.14.Final'
 }
+
+def dockerBuildDir = 'build/docker/'
+
+task createDockerfile(type: Dockerfile) {
+    destFile = project.file("$dockerBuildDir/Dockerfile")
+    from "gradle:6.3.0-jdk8 AS build"
+    instruction "COPY --chown=gradle:gradle . /home/gradle/src"
+    instruction "WORKDIR /home/gradle/src"
+    instruction "RUN gradle bootJar"
+    from "openjdk:8-jre-slim"
+    instruction "RUN mkdir /app"
+    instruction "COPY --from=build /home/gradle/src/build/libs/chat-server-0.0.1-SNAPSHOT.jar /app/chat-server-0.0.1-SNAPSHOT.jar"
+    instruction "ENTRYPOINT [\"java\", \"-Dspring.data.mongodb.uri=mongodb://database:27017/db\", \"-jar\", \"/app/chat-server-0.0.1-SNAPSHOT.jar\"]"
+}
+
+def clearProductionFiles() {
+    delete 'docker'
+}
+
+task clear() {
+    clearProductionFiles()
+}
+
+clean.dependsOn clear
+
+task buildImage(type: DockerBuildImage, dependsOn: 'createDockerfile') {
+    inputDir = project.file(".")
+    dockerFile = createDockerfile.destFile
+    imageId = "123"
+    doLast {
+        clearProductionFiles()
+    }
+}
+

--- a/chat-server/build.gradle
+++ b/chat-server/build.gradle
@@ -4,7 +4,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 buildscript {
     ext {
         depVersion = [
-                gradle_docker_plugin: "6.4.0"
+                gradle_docker_plugin: '6.4.0'
         ]
     }
     
@@ -19,11 +19,11 @@ buildscript {
 plugins {
     id 'org.springframework.boot' version '2.2.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'com.bmuschko.docker-spring-boot-application' version '6.4.0'
     id 'java'
 }
 
 apply plugin: 'com.bmuschko.docker-remote-api'
-apply plugin: 'com.bmuschko.docker-java-application'
 
 group = 'com.vinnik.chat'
 version = '0.0.1-SNAPSHOT'
@@ -50,6 +50,7 @@ task createDockerfile(type: Dockerfile) {
     from "gradle:6.3.0-jdk8 AS build"
     instruction "COPY --chown=gradle:gradle . /home/gradle/src"
     instruction "WORKDIR /home/gradle/src"
+    instruction "RUN cd .."
     instruction "RUN gradle bootJar"
     from "openjdk:8-jre-slim"
     instruction "RUN mkdir /app"
@@ -67,12 +68,8 @@ task clear() {
 
 clean.dependsOn clear
 
-task buildImage(type: DockerBuildImage, dependsOn: 'createDockerfile') {
-    inputDir = project.file(".")
-    dockerFile = createDockerfile.destFile
-    imageId = "123"
-    doLast {
-        clearProductionFiles()
-    }
+task buildImage(type: DockerBuildImage) {
+    inputDir = file(dockerBuildDir)
+    images.add('myapp:latest')
 }
 

--- a/chat-server/docker-compose.yml
+++ b/chat-server/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  api-database:
+    image: mongo:3.2.4
+    container_name: "api-database"
+    ports:
+      - 27017:27017
+    command: --smallfiles
+  api:
+    image: chat-server
+    ports:
+      - 9091:8080
+    links:
+      - api-database
+}

--- a/chat-server/docker-compose.yml
+++ b/chat-server/docker-compose.yml
@@ -1,17 +1,17 @@
 version: "3"
 services:
-  api:
+  gitlogue-server:
     image: gitlogue-server
     ports:
       - 8080:8080
     depends_on:
-      - api-database
+      - database
     environment:
-      SPRING_DATA_MONGODB_URI: mongodb://api-database:27017/db
-  api-database:
+      SPRING_DATA_MONGODB_URI: mongodb://database:27017/db
+  database:
     image: mongo:3.2.4
-    container_name: "api-database"
-    hostname: api-database
+    container_name: "database"
+    hostname: database
     ports:
       - 27017:27017
     command: mongod 

--- a/chat-server/docker-compose.yml
+++ b/chat-server/docker-compose.yml
@@ -1,15 +1,17 @@
 version: "3"
 services:
+  api:
+    image: gitlogue-server
+    ports:
+      - 8080:8080
+    depends_on:
+      - api-database
+    environment:
+      SPRING_DATA_MONGODB_URI: mongodb://api-database:27017/db
   api-database:
     image: mongo:3.2.4
     container_name: "api-database"
+    hostname: api-database
     ports:
       - 27017:27017
-    command: --smallfiles
-  api:
-    image: chat-server
-    ports:
-      - 9091:8080
-    links:
-      - api-database
-}
+    command: mongod 

--- a/chat-server/src/main/resources/application.properties
+++ b/chat-server/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 #mongodb
-spring.data.mongodb.host=localhost
-spring.data.mongodb.port=27017
-spring.data.mongodb.database=test
+server.address=0.0.0.0 # Bind all
+spring.data.mongodb.host=api-database

--- a/chat-server/src/main/resources/application.properties
+++ b/chat-server/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 #mongodb
 server.address=0.0.0.0
-spring.data.mongodb.host=api-database
+spring.data.mongodb.host=database
 spring.data.mongodb.port=27017
-spring.data.mongodb.uri=mongodb://api-database:27017/db
+spring.data.mongodb.uri=mongodb://database:27017/db

--- a/chat-server/src/main/resources/application.properties
+++ b/chat-server/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 #mongodb
-server.address=0.0.0.0 # Bind all
+server.address=0.0.0.0
 spring.data.mongodb.host=api-database
+spring.data.mongodb.port=27017
+spring.data.mongodb.uri=mongodb://api-database:27017/db


### PR DESCRIPTION
#28 
We have to ship the server. It could be done in multiple ways, for example: JDK, VM image, container.
Containers are really popular nowadays - it has advantages of VMs in terms of encapsulation, yet they're relatively lightweight.
In order to launch container, you should have a container runtime, for example - Docker. In order to run your app inside it, you'd have to build a docker image with it.
Packaging your app into Docker image has multiple advantages, such as:

OS independent (as long as it supports docker);
Predefined environment - user shouldn't take time to install, for example, JDK;
In this task, I'd like you to package only server written with Spring.

#29
We have 2 components in back-end: server and database. They should interact between each other, so it'd be useful to launch them both using one command.
Since, at this point, server should be packaged into docker container, we could use docker-compose to archive the desired one-command start up.

Things that docker-compose up should do:
- launch container with server;
- launch container with mongoDB;
- establish network between those two;
